### PR TITLE
Remove use of axios

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -9,6 +9,8 @@ release the new version.
 
 ## Unreleased
 
+### Changed
+
 - #1320: Update Electron to v43.
 - #1314: Temporarily force auto-update of the official Quick Start app, to get
   users onto the version with cloud telemetry.
@@ -16,6 +18,7 @@ release the new version.
   any version (latest = on, other = off)
 - #1311: Feature for updating apps with `auto-update` enabled in package.json.
   The update process triggers when clicking **Open**.
+- #1285: Removed use of axios at build time.
 
 ## 5.3.2
 

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -18,7 +18,7 @@ release the new version.
   any version (latest = on, other = off)
 - #1311: Feature for updating apps with `auto-update` enabled in package.json.
   The update process triggers when clicking **Open**.
-- #1285: Removed use of axios at build time.
+- #1285: Removed use of axios at build time and now actually checks checksums.
 
 ## 5.3.2
 

--- a/build/bundleApps.js
+++ b/build/bundleApps.js
@@ -60,7 +60,7 @@ const isAppBundled = appJSONUrl =>
     BUNDLE_APPS.find(app => app === path.parse(appJSONUrl).name);
 
 const parseSourceFile = appUrls =>
-    Promise.allSettled(
+    Promise.all(
         appUrls.apps.map(async appJSONUrl => {
             const dstPath = url =>
                 path.join('resources', 'prefetched', path.basename(url));
@@ -68,7 +68,7 @@ const parseSourceFile = appUrls =>
             await downloadFile(appJSONUrl, dstPath(appJSONUrl), false);
             const appJSON = JSON.parse(fs.readFileSync(dstPath(appJSONUrl)));
 
-            await Promise.allSettled([
+            await Promise.all([
                 downloadFile(appJSON.iconUrl, dstPath(appJSON.iconUrl), false),
                 downloadFile(
                     appJSON.releaseNotesUrl,
@@ -112,7 +112,7 @@ const parseSourceFile = appUrls =>
                 });
             }
 
-            await Promise.allSettled(promises);
+            await Promise.all(promises);
         }),
     );
 

--- a/build/bundleApps.js
+++ b/build/bundleApps.js
@@ -65,15 +65,14 @@ const parseSourceFile = appUrls =>
             const dstPath = url =>
                 path.join('resources', 'prefetched', path.basename(url));
 
-            await downloadFile(appJSONUrl, dstPath(appJSONUrl), false);
+            await downloadFile(appJSONUrl, dstPath(appJSONUrl));
             const appJSON = JSON.parse(fs.readFileSync(dstPath(appJSONUrl)));
 
             await Promise.all([
-                downloadFile(appJSON.iconUrl, dstPath(appJSON.iconUrl), false),
+                downloadFile(appJSON.iconUrl, dstPath(appJSON.iconUrl)),
                 downloadFile(
                     appJSON.releaseNotesUrl,
                     dstPath(appJSON.releaseNotesUrl),
-                    false,
                 ),
             ]);
 
@@ -96,7 +95,6 @@ const parseSourceFile = appUrls =>
                         appBundlesPath,
                         path.basename(latestVersion.tarballUrl),
                     ),
-                    false,
                 ),
             );
 
@@ -120,7 +118,6 @@ exports.default = async () => {
     await downloadFile(
         SOURCE_URL,
         `resources/prefetched/${path.basename(SOURCE_URL)}`,
-        false,
     );
 
     const appUrls = JSON.parse(

--- a/build/getBundledResources.js
+++ b/build/getBundledResources.js
@@ -15,5 +15,5 @@ exports.default = async () => {
         recursive: true,
     });
 
-    await Promise.allSettled([getJlink(), bundleApps()]);
+    await Promise.all([getJlink(), bundleApps()]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@electron/remote": "^2.1.2",
-                "axios": "0.22.0",
                 "chmodr": "1.2.0",
                 "electron-store": "8.1.0",
                 "electron-updater": "4.3.7",
@@ -7072,14 +7071,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/axios": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
-            "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
         "node_modules/axobject-query": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -11665,25 +11656,6 @@
             "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
             "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==",
             "dev": true
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/for-each": {
             "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     },
     "dependencies": {
         "@electron/remote": "^2.1.2",
-        "axios": "0.22.0",
         "chmodr": "1.2.0",
         "electron-store": "8.1.0",
         "electron-updater": "4.3.7",

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -38,19 +38,18 @@ const createChecksumChecker = async fileUrl => {
             const calculatedChecksum = hash.digest('hex');
 
             if (calculatedChecksum !== expectedChecksum) {
-                await unlink(destinationFile);
                 console.log('Calculated checksum:', calculatedChecksum);
                 console.log('Expected checksum:  ', expectedChecksum);
+
+                await unlink(destinationFile);
                 throw new Error('Checksum verification failed.');
             }
         },
     };
 };
 
-module.exports = async (fileUrl, destinationFile, useChecksum = true) => {
-    const checksumChecker = useChecksum
-        ? await createChecksumChecker(fileUrl)
-        : null;
+module.exports = async (fileUrl, destinationFile) => {
+    const checksumChecker = await createChecksumChecker(fileUrl);
 
     console.log('🏎️ Started Download', fileUrl);
     const response = await fetch(fileUrl);
@@ -65,22 +64,12 @@ module.exports = async (fileUrl, destinationFile, useChecksum = true) => {
 
     await mkdir(path.dirname(destinationFile), { recursive: true });
 
-    let pipelineStream = response.body;
-
-    if (checksumChecker != null) {
-        pipelineStream = pipelineStream.pipeThrough(
-            checksumChecker.transformStream(),
-        );
-    }
-
-    await pipelineStream.pipeTo(
-        Writable.toWeb(fs.createWriteStream(destinationFile)),
-    );
+    await response.body
+        .pipeThrough(checksumChecker.transformStream())
+        .pipeTo(Writable.toWeb(fs.createWriteStream(destinationFile)));
 
     console.log('🏁 Finish Download', fileUrl);
     console.log('🏁 Saved to', destinationFile);
 
-    if (checksumChecker != null) {
-        await checksumChecker.verify(destinationFile);
-    }
+    await checksumChecker.verify(destinationFile);
 };

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -47,7 +47,7 @@ const createChecksumChecker = async fileUrl => {
     };
 };
 
-module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
+module.exports = async (fileUrl, destinationFile, useChecksum = true) => {
     const checksumChecker = useChecksum
         ? await createChecksumChecker(fileUrl)
         : null;

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -4,66 +4,63 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-const axios = require('axios');
-const fs = require('fs');
-const { mkdir } = require('fs/promises');
-const path = require('path');
 const crypto = require('crypto');
+const fs = require('fs');
+const { mkdir, unlink } = require('fs/promises');
+const path = require('path');
+const { Writable } = require('stream');
 
 const downloadChecksum = async fileUrl => {
     console.log('Downloading', fileUrl);
-    try {
-        const { status, data } = await axios.get(fileUrl);
-        if (status !== 200) {
-            throw new Error(
-                `Unable to download ${fileUrl}. Got status code ${status}`,
-            );
-        }
-        return data;
-    } catch (error) {
-        throw new Error(`Unable to download ${fileUrl}: ${error.message}`);
+    const response = await fetch(fileUrl);
+    if (!response.ok) {
+        throw new Error(
+            `Unable to download ${fileUrl}. Got status code ${response.status}`,
+        );
     }
+
+    return (await response.text()).trim().split(/\s+/)[0];
 };
 
 module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
     const hash = crypto.createHash('sha256');
 
-    console.log('Started Download', fileUrl);
-    const { status, data: stream } = await axios.get(fileUrl, {
-        responseType: 'stream',
-    });
-    if (status !== 200) {
+    console.log('🏎️ Started Download', fileUrl);
+    const response = await fetch(fileUrl);
+    if (!response.ok) {
         throw new Error(
-            `Unable to download ${fileUrl}. Got status code ${status}`,
+            `Unable to download ${fileUrl}. Got status code ${response.status}`,
         );
     }
+    if (!response.body) {
+        throw new Error(`Unable to download ${fileUrl}: Empty response body`);
+    }
+
     await mkdir(path.dirname(destinationFile), { recursive: true });
-    return new Promise((resolve, reject) => {
-        const file = fs.createWriteStream(destinationFile);
-        stream.pipe(file);
-        stream.on('data', data => hash.update(data));
-        stream.on('error', reject);
-        stream.on('end', () => {
-            file.end(async () => {
-                console.log('🏁 Finish Download', fileUrl);
-                console.log('🏁 Saved to', destinationFile);
-                if (useChecksum) {
-                    const calculatedChecksum = hash.digest('hex');
-                    const expectedChecksum = await downloadChecksum(
-                        `${fileUrl}.sha256`,
-                    );
 
-                    if (calculatedChecksum !== expectedChecksum) {
-                        fs.unlinkSync(destinationFile);
-                        console.log('Calculated checksum:', calculatedChecksum);
-                        console.log('Expected checksum:  ', expectedChecksum);
-                        reject(new Error('Checksum verification failed.'));
-                        return;
-                    }
-                }
-
-                resolve();
-            });
-        });
+    const hashTransform = new TransformStream({
+        transform(chunk, controller) {
+            hash.update(chunk);
+            controller.enqueue(chunk);
+        },
     });
+
+    await response.body
+        .pipeThrough(hashTransform)
+        .pipeTo(Writable.toWeb(fs.createWriteStream(destinationFile)));
+
+    console.log('🏁 Finish Download', fileUrl);
+    console.log('🏁 Saved to', destinationFile);
+
+    if (useChecksum) {
+        const calculatedChecksum = hash.digest('hex');
+        const expectedChecksum = await downloadChecksum(`${fileUrl}.sha256`);
+
+        if (calculatedChecksum !== expectedChecksum) {
+            await unlink(destinationFile);
+            console.log('Calculated checksum:', calculatedChecksum);
+            console.log('Expected checksum:  ', expectedChecksum);
+            throw new Error('Checksum verification failed.');
+        }
+    }
 };

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -10,20 +10,47 @@ const { mkdir, unlink } = require('fs/promises');
 const path = require('path');
 const { Writable } = require('stream');
 
-const downloadChecksum = async fileUrl => {
-    console.log('Downloading', fileUrl);
+const downloadChecksumFile = async fileUrl => {
+    console.log('Downloading checksum file', fileUrl);
     const response = await fetch(fileUrl);
     if (!response.ok) {
         throw new Error(
             `Unable to download ${fileUrl}. Got status code ${response.status}`,
         );
     }
-
     return (await response.text()).trim().split(/\s+/)[0];
 };
 
-module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
+const createChecksumChecker = async fileUrl => {
+    const expectedChecksum = await downloadChecksumFile(`${fileUrl}.sha256`);
     const hash = crypto.createHash('sha256');
+
+    return {
+        transformStream: () =>
+            new TransformStream({
+                transform: (chunk, controller) => {
+                    hash.update(chunk);
+                    controller.enqueue(chunk);
+                },
+            }),
+
+        verify: async destinationFile => {
+            const calculatedChecksum = hash.digest('hex');
+
+            if (calculatedChecksum !== expectedChecksum) {
+                await unlink(destinationFile);
+                console.log('Calculated checksum:', calculatedChecksum);
+                console.log('Expected checksum:  ', expectedChecksum);
+                throw new Error('Checksum verification failed.');
+            }
+        },
+    };
+};
+
+module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
+    const checksumChecker = useChecksum
+        ? await createChecksumChecker(fileUrl)
+        : null;
 
     console.log('🏎️ Started Download', fileUrl);
     const response = await fetch(fileUrl);
@@ -38,29 +65,22 @@ module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
 
     await mkdir(path.dirname(destinationFile), { recursive: true });
 
-    const hashTransform = new TransformStream({
-        transform(chunk, controller) {
-            hash.update(chunk);
-            controller.enqueue(chunk);
-        },
-    });
+    let pipelineStream = response.body;
 
-    await response.body
-        .pipeThrough(hashTransform)
-        .pipeTo(Writable.toWeb(fs.createWriteStream(destinationFile)));
+    if (checksumChecker != null) {
+        pipelineStream = pipelineStream.pipeThrough(
+            checksumChecker.transformStream(),
+        );
+    }
+
+    await pipelineStream.pipeTo(
+        Writable.toWeb(fs.createWriteStream(destinationFile)),
+    );
 
     console.log('🏁 Finish Download', fileUrl);
     console.log('🏁 Saved to', destinationFile);
 
-    if (useChecksum) {
-        const calculatedChecksum = hash.digest('hex');
-        const expectedChecksum = await downloadChecksum(`${fileUrl}.sha256`);
-
-        if (calculatedChecksum !== expectedChecksum) {
-            await unlink(destinationFile);
-            console.log('Calculated checksum:', calculatedChecksum);
-            console.log('Expected checksum:  ', expectedChecksum);
-            throw new Error('Checksum verification failed.');
-        }
+    if (checksumChecker != null) {
+        await checksumChecker.verify(destinationFile);
     }
 };


### PR DESCRIPTION
Use fetch from Node.js instead of axios.

Because this is only used at build time, risk is even lower.

Also extracted the checksum checking and while doing so detected (and fixed) that we never checked the checksums, probably since a previous refactoring. 🙈